### PR TITLE
Update storage.py

### DIFF
--- a/django_cos_storage/storage.py
+++ b/django_cos_storage/storage.py
@@ -7,6 +7,7 @@ from django.utils.deconstruct import deconstructible
 from qcloud_cos import CosConfig, CosS3Client
 from qcloud_cos.cos_exception import CosServiceError
 import pkg_resources
+import os.path
 
 from .file import TencentCOSFile
 
@@ -132,7 +133,7 @@ class TencentCOSStorage(Storage):
         self.client.upload_file_from_buffer(
             self.bucket, self._full_path(name), content, **upload_kwargs
         )
-        return name
+        return os.path.relpath(name, self.root_path)
 
     def get_available_name(self, name, max_length=None):
         name = self._full_path(name)


### PR DESCRIPTION
Fix #2
根据 Django storage 开发的最佳实践以及官方提供的 storage 示例，在保存路径时应当只保存相对路径。 在 4.x 的版本中，save 方法调用_save 方法后后会调用文件路径检查函数，如果为绝对路径则会被阻止。 修改后如果需要获取文件的完整路径，直接用 Field 的url 方法即可。